### PR TITLE
Treat empty URL as an internal page

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -18,5 +18,5 @@ function onClick(ev) {
  * Return `true` is the link is external and should be opened in a new tab
  */
 function isExternalHref(href) {
-  return !/\.atlassian\.(net|com)/g.test(href) && !/^mailto:/.test(href);
+  return '' != href && !/\.atlassian\.(net|com)/g.test(href) && !/^mailto:/.test(href);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "JIRA - Open external links in a new tab",
-  "version": "1.0",
+  "version": "1.01",
   "description": "JIRA - Open external links in a new tab",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "content_scripts": [
     {
       "matches": [


### PR DESCRIPTION
The [GitHub for Jira](https://github.com/atlassian/github-for-jira) extension generates PR, branch and commit links. Clicking any of them opens a modal. When `jira-new-tab` is used, it causes a side-effect of opening an empty browser tab. 
<img width="421" alt="Screenshot 2023-02-27 at 12 05 23" src="https://user-images.githubusercontent.com/583112/221550870-d86667b7-da0a-4dbb-8261-6db24f2a9b61.png">


My research indicated that the URL being opened is an empty string.

The solution in this PR is to simply treat the empty string in `href` as an internal page, that doesn't open in a new tab. 

I also bumped the extension manifest version to avoid it from being blocked by Google.